### PR TITLE
Fix artifact upload action deprecation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: .
       - uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- update `actions/upload-pages-artifact` to v3 so that GH Actions no longer uses the deprecated v3 upload-artifact

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847a403b240832a9c77d7ebffedfc99